### PR TITLE
Exception typo

### DIFF
--- a/lib/comma.rb
+++ b/lib/comma.rb
@@ -13,7 +13,7 @@ else
   begin
     # try faster csv
     require 'fastercsv'
-  rescue Error => e
+  rescue Exception => e
     if defined? Rails
       Rails.logger.info "FasterCSV not installed, falling back on CSV"
     else


### PR DESCRIPTION
Hi Marcus

Today we deployed to a server which did not have fastercsv installed, and got a stange error about Error being an uninitialized constant. Turned out to be a bug in Comma.

I have patched it, and hope that you will pull the changes into master.

Have a nice day
/Benjamin
