### PR TITLE
Fix deprecation warning when upgrading to Rails 2.3.10

### DIFF
--- a/lib/comma.rb
+++ b/lib/comma.rb
@@ -1,5 +1,5 @@
 # conditional loading of activesupport
-if defined? Rails and Rails.version < '2.3.5'
+if defined? Rails and (Rails.version.split('.').map(&:to_i) <=> [2,3,5]) < 0
   require 'activesupport'
 else
   require 'active_support/core_ext/class/inheritable_attributes'


### PR DESCRIPTION
Comparison check does not take into account double digit values for RAILS::VERSION::TINY
