### PR TITLE
Rails 3 Render Support

### DIFF
--- a/lib/comma/render_as_csv.rb
+++ b/lib/comma/render_as_csv.rb
@@ -32,10 +32,19 @@ module RenderAsCSV
     content = options[:content]
     style   = options[:style]
 
-    render :status => status, :text => Proc.new { |response, output|
-      output.write FasterCSV.generate_line(content.first.to_comma_headers(style))
-      content.each { |line| output.write FasterCSV.generate_line(line.to_comma(style)) }
-    }
+    # If Rails 2.x
+    if defined? Rails and (Rails.version.split('.').map(&:to_i) <=> [2,3,5]) < 0
+      render :status => status, :text => Proc.new { |response, output|
+        output.write FasterCSV.generate_line(content.first.to_comma_headers(style))
+        content.each { |line| output.write FasterCSV.generate_line(line.to_comma(style)) }
+      }
+    else # If Rails 3.x
+      self.status = status
+      self.response_body = proc { |response, output|
+        output.write FasterCSV.generate_line(content.first.to_comma_headers(style))
+        content.each { |line| output.write FasterCSV.generate_line(line.to_comma(style)) }
+      }
+    end
   end
 end
 


### PR DESCRIPTION
Update Rails render method to support Rails 3 response_body as render :text => proc is deprecated.

See: https://rails.lighthouseapp.com/projects/8994/tickets/4554-render-text-proc-regression
