### PR TITLE
Fixes 'class_inheritable_attribute is deprecated' error for Rails 3.1

### DIFF
--- a/lib/comma/object.rb
+++ b/lib/comma/object.rb
@@ -1,5 +1,5 @@
 class Object
-  class_inheritable_accessor :comma_formats
+  class_attribute :comma_formats
 
   def self.comma(style = :default, &block)
     (self.comma_formats ||= {})[style] = block


### PR DESCRIPTION
Fixes the deprecation error by changing a line in object.rb.
