### PR TITLE
Pass options through to to_comma when using a renderer

### DIFF
--- a/lib/comma/render_as_csv.rb
+++ b/lib/comma/render_as_csv.rb
@@ -1,7 +1,7 @@
 if defined?(ActionController::Renderers) && ActionController::Renderers.respond_to?(:add)
   ActionController::Renderers.add :csv do |obj, options|
     filename = options[:filename] || 'data'
-    send_data obj.to_comma, :type => Mime::CSV, :disposition => "attachment; filename=#{filename}.csv"
+    send_data obj.to_comma(options), :type => Mime::CSV, :disposition => "attachment; filename=#{filename}.csv"
   end
 else
   module RenderAsCSV


### PR DESCRIPTION
Fixes issue introduced in https://github.com/crafterm/comma/commit/77276f07881e1e86fcb48cdb91b0bdbd6de4ad23 where options such as the :style were being ignored
