### PR TITLE
FasterCSV dependency fix

### DIFF
--- a/comma.gemspec
+++ b/comma.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency(%q<fastercsv>, ["1.5.4"])
+  s.add_runtime_dependency(%q<fastercsv>, ["~> 1.5.4"])
 
   s.add_development_dependency(%q<rake>, ["0.8.7"])
   s.add_development_dependency('sqlite3', '~> 1.3.4')


### PR DESCRIPTION
FasterCSV has been updated to version 1.5.5, which was causing problems in a rails 2.3 install with bundler.  I updated the gemspec dependency for FasterCSV to '~> 1.5.4' so it'll use the newer version if it's there.
