### PR TITLE
Allow id attribute to execute block as other attributes

### DIFF
--- a/lib/comma/extractors.rb
+++ b/lib/comma/extractors.rb
@@ -13,8 +13,8 @@ module Comma
       @results
     end
 
-    def id(*args)
-      method_missing(:id, *args)
+    def id(*args, &block)
+      method_missing(:id, *args, &block)
     end
   end
 

--- a/spec/comma/extractors_spec.rb
+++ b/spec/comma/extractors_spec.rb
@@ -89,3 +89,17 @@ describe Comma::DataExtractor do
   end
 
 end
+
+describe Comma::DataExtractor, 'id attribute' do
+  before do
+    @data = Class.new(Struct.new(:id)) do
+      comma do
+        id 'ID' do |id| '42' end
+      end
+    end.new(1).to_comma
+  end
+
+  it 'id attribute should yield block' do
+    @data.should include('42')
+  end
+end


### PR DESCRIPTION
This attribute is rarely used, but just for consistency.
