### PR TITLE
Generate static value column

### DIFF
--- a/lib/comma/extractors.rb
+++ b/lib/comma/extractors.rb
@@ -37,6 +37,10 @@ module Comma
         end
       end
     end
+
+    def __static_column__(header = '', &block)
+      @results << header
+    end
   end
 
   class DataExtractor < Extractor
@@ -69,6 +73,10 @@ module Comma
           raise "Unknown data symbol #{arg.inspect}"
         end
       end
+    end
+
+    def __static_column__(header = nil, &block)
+      @results << (block ? yield : nil)
     end
   end
 end

--- a/spec/comma/extractors_spec.rb
+++ b/spec/comma/extractors_spec.rb
@@ -50,6 +50,22 @@ describe Comma::HeaderExtractor do
 
 end
 
+describe Comma::HeaderExtractor, 'with static column method' do
+  before do
+    @headers = Class.new(Struct.new(:id, :name)) do
+      comma do
+        __static_column__
+        __static_column__ 'STATIC'
+        __static_column__ 'STATIC' do '' end
+      end
+    end.new(1, 'John Doe').to_comma_headers
+  end
+
+  it 'should extract headers' do
+    @headers.should eq(['', 'STATIC', 'STATIC'])
+  end
+end
+
 describe Comma::DataExtractor do
 
   before do
@@ -101,5 +117,21 @@ describe Comma::DataExtractor, 'id attribute' do
 
   it 'id attribute should yield block' do
     @data.should include('42')
+  end
+end
+
+describe Comma::DataExtractor, 'with static column method' do
+  before do
+    @data = Class.new(Struct.new(:id, :name)) do
+      comma do
+        __static_column__
+        __static_column__ 'STATIC'
+        __static_column__ 'STATIC' do '' end
+      end
+    end.new(1, 'John Doe').to_comma
+  end
+
+  it 'should extract headers' do
+    @data.should eq([nil, nil, ''])
   end
 end


### PR DESCRIPTION
Sometimes, I need to generate CSV format data that has columns with static values. You could do that by supplying  block that returns static value like:

``` ruby
comma :static_column do
  publisher 'Publisher' do 'Foo, Inc.' end
end
```

But, it would be clearer if we have special field name to indicate producing static data column like:

``` ruby
comma :static_column do
  __static_column__ 'Publisher' do 'Foo, Inc.' end
end
```
