### PR TITLE
Add bundler to development dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,9 +32,10 @@ PLATFORMS
 
 DEPENDENCIES
   appraisal (~> 0.4.1)
+  bundler
   comma!
   fastercsv
   rake (~> 0.9.2)
   rspec (~> 2.8.0)
-  simplecov
+  simplecov (~> 0.6.0)
   sqlite3 (~> 1.3.4)

--- a/comma.gemspec
+++ b/comma.gemspec
@@ -18,11 +18,11 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_development_dependency(%q<rake>, ["~> 0.9.2"])
-  s.add_development_dependency('sqlite3', '~> 1.3.4')
-  s.add_development_dependency(%q<appraisal>, ["~> 0.4.1"])
-
-  s.add_development_dependency('rspec', '~> 2.8.0')
-  s.add_development_dependency 'simplecov'
+  s.add_development_dependency 'bundler', ['>= 0']
+  s.add_development_dependency 'rake', ['~> 0.9.2']
+  s.add_development_dependency 'sqlite3', ['~> 1.3.4']
+  s.add_development_dependency 'appraisal', ['~> 0.4.1']
+  s.add_development_dependency 'rspec', ['~> 2.8.0']
+  s.add_development_dependency 'simplecov', ['~> 0.6.0']
 
 end


### PR DESCRIPTION
It seems that recent builds on Travis CI are failing because bundler is missing.
