### PR TITLE
Fix failing travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 language: ruby
 rvm:
-  - ree
-  - 1.8.7
-  - 1.9.2
-  - 1.9.3
-  - rbx-18mode
-
-script: "bundle exec rake appraisal:install && bundle exec rake appraisal spec"
+  - 'ree'
+  - '1.8.7'
+  - '1.9.2'
+  - '1.9.3'
+  - '2.0.0'
+  - 'rbx-18mode'
+  - 'rbx-19mode'
+before_script: 'rake appraisal:install'
+script: 'rake appraisal spec'


### PR DESCRIPTION
This PR should fix error (see below) in travis build.

```
$ bundle exec rake appraisal:install && bundle exec rake appraisal spec
>> bundle install --gemfile=/home/travis/build/crafterm/comma/gemfiles/rails3.0.9.gemfile
/home/travis/.rvm/rubies/ree-1.8.7-2012.02/lib/ruby/site_ruby/1.8/rubygems/dependency.rb:296:in `to_specs': Could not find 'bundler' (>= 0) among 12 total gem(s) (Gem::LoadError)
```
