### PR TITLE
Extract nil value

### DIFF
--- a/lib/comma/extractors.rb
+++ b/lib/comma/extractors.rb
@@ -10,16 +10,23 @@ module Comma
 
     def results
       instance_eval &@block
-      @results
+      @results.map { |r| convert_to_data_value(r) }
     end
 
     def id(*args, &block)
       method_missing(:id, *args, &block)
     end
+
+    private
+
+    def convert_to_data_value(result)
+      result.nil? ? result : result.to_s
+    end
+
   end
 
   class HeaderExtractor < Extractor
-    
+
     def method_missing(sym, *args, &block)
       @results << sym.to_s.humanize if args.blank?
       args.each do |arg|
@@ -43,32 +50,51 @@ module Comma
 
     def method_missing(sym, *args, &block)
       if args.blank?
-        result = block ? yield(@instance.send(sym)) : @instance.send(sym)
-        @results << result.to_s
+        @results << yield_block_with_value(
+                      extract_value_from_object(@instance, sym), &block)
       end
 
       args.each do |arg|
         case arg
         when Hash
           arg.each do |k, v|
-            if block
-              @results << (@instance.send(sym).nil? ? '' : yield(@instance.send(sym).send(k)).to_s )
-            else
-              @results << (@instance.send(sym).nil? ? '' : @instance.send(sym).send(k).to_s )
-            end
+            @results << yield_block_with_value(
+                          extract_value_from_object(
+                            get_association(@instance, sym), k), &block)
           end
         when Symbol
-          if block
-            @results << (@instance.send(sym).nil? ? '' : yield(@instance.send(sym).send(arg)).to_s)
-          else
-            @results << ( @instance.send(sym).nil? ? '' : @instance.send(sym).send(arg).to_s )
-          end
+          @results << yield_block_with_value(
+                        extract_value_from_object(
+                          get_association(@instance, sym), arg), &block)
         when String
-          @results << (block ? yield(@instance.send(sym)) : @instance.send(sym)).to_s
+          @results << yield_block_with_value(
+              extract_value_from_object(@instance, sym), &block)
         else
           raise "Unknown data symbol #{arg.inspect}"
         end
       end
     end
+
+    private
+
+    def yield_block_with_value(value, &block)
+      block ? yield(value) : value
+    end
+
+    def extract_value_from_object(object, method)
+      object.send(method)
+    end
+
+    def get_association(model, association_name)
+      model.send(association_name) || NullAssociation.new
+    end
+
   end
+
+  class NullAssociation < Class.const_defined?(:BasicObject) ? ::BasicObject : ::Object
+    def method_missing(symbol, *args, &block)
+      nil
+    end
+  end
+
 end

--- a/spec/comma/extractors_spec.rb
+++ b/spec/comma/extractors_spec.rb
@@ -103,3 +103,19 @@ describe Comma::DataExtractor, 'id attribute' do
     @data.should include('42')
   end
 end
+
+describe Comma::DataExtractor, 'nil value' do
+  before do
+    @data = Class.new(Struct.new(:id, :name)) do
+      comma do
+        name
+        name 'Name'
+        name 'Name' do |name| nil end
+      end
+    end.new(1, nil).to_comma
+  end
+
+  it 'should extract nil' do
+    @data.should eq([nil, nil, nil])
+  end
+end


### PR DESCRIPTION
In CSV class, `nil` value has special meaning. For example,

``` ruby
require 'csv'
puts CSV.generate { |csv| csv << [nil, ''] }
```

code above would produce `,""`. `nil` would become empty, no quotes around.

So, it would be nice if comma doesn't call `#to_s` on `nil` values.
