### PR TITLE
Add licenses (MIT) to gemspec

### DIFF
--- a/comma.gemspec
+++ b/comma.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
+  s.licenses = ['MIT']
+
   s.add_development_dependency(%q<rake>, ["~> 0.9.2"])
   s.add_development_dependency('sqlite3', '~> 1.3.4')
   s.add_development_dependency(%q<appraisal>, ["~> 0.4.1"])


### PR DESCRIPTION
It would show on [project page](https://rubygems.org/gems/comma) (under Owners) of Rubygems.org, so it would be easier to find out.
