### PR TITLE
Add ruby 2.0.0 to compatibility in README.markdown

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -5,7 +5,7 @@ http://github.com/crafterm/comma
 ##COMPATIBILITY
 The mainline of this project builds gems to the 3.x version series, and is compatible and tested with :
 
-* Ruby 1.8.7, 1.9.2, 1.9.3
+* Ruby 1.8.7, 1.9.2, 1.9.3, 2.0.0
 * REE 1.8.7
 * RBX 1.8
 * Rails 3.x (all versions, with ActiveRecord and Mongoid support)


### PR DESCRIPTION
ruby 2.0.0 should be in compatibility because tests have been executed in ruby 2.0.0 and are passed on Travis CI.
