### PR TITLE
Ignore .ruby-version and .ruby-gemset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ pkg/*
 spec/rails_app/log
 spec/rails_app/db/development.sqlite*
 .rbx/
+.ruby-*
+coverage/*


### PR DESCRIPTION
These files can be used in rvm or rbenv.

Also files in coverage are ignored in this PR.
