### PR TITLE
Adjust path and version in gemfile lock files

### DIFF
--- a/gemfiles/active3.0.9.gemfile.lock
+++ b/gemfiles/active3.0.9.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
-  remote: /Users/tom/src/personal/comma
+  remote: ..
   specs:
-    comma (3.0.4)
+    comma (3.0.5)
 
 GEM
   remote: http://rubygems.org/

--- a/gemfiles/active3.1.1.gemfile.lock
+++ b/gemfiles/active3.1.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
-  remote: /Users/tom/src/personal/comma
+  remote: ..
   specs:
-    comma (3.0.4)
+    comma (3.0.5)
 
 GEM
   remote: http://rubygems.org/

--- a/gemfiles/active3.1.12.gemfile.lock
+++ b/gemfiles/active3.1.12.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
-  remote: /Users/tom/src/personal/comma
+  remote: ..
   specs:
-    comma (3.0.4)
+    comma (3.0.5)
 
 GEM
   remote: http://rubygems.org/

--- a/gemfiles/active3.2.1.gemfile.lock
+++ b/gemfiles/active3.2.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
-  remote: /Users/tom/Development/Projects/comma
+  remote: ..
   specs:
-    comma (3.0.3)
+    comma (3.0.5)
 
 GEM
   remote: http://rubygems.org/

--- a/gemfiles/active3.2.11.gemfile.lock
+++ b/gemfiles/active3.2.11.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
-  remote: /Users/tom/src/personal/comma
+  remote: ..
   specs:
-    comma (3.0.4)
+    comma (3.0.5)
 
 GEM
   remote: http://rubygems.org/

--- a/gemfiles/active3.2.8.gemfile.lock
+++ b/gemfiles/active3.2.8.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
-  remote: /Users/tom/development/projects/current/comma
+  remote: ..
   specs:
-    comma (3.0.3)
+    comma (3.0.5)
 
 GEM
   remote: http://rubygems.org/

--- a/gemfiles/rails3.0.9.gemfile.lock
+++ b/gemfiles/rails3.0.9.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
-  remote: /Users/tom/src/personal/comma
+  remote: ..
   specs:
-    comma (3.0.4)
+    comma (3.0.5)
 
 GEM
   remote: http://rubygems.org/

--- a/gemfiles/rails3.1.1.gemfile.lock
+++ b/gemfiles/rails3.1.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
-  remote: /Users/tom/src/personal/comma
+  remote: ..
   specs:
-    comma (3.0.4)
+    comma (3.0.5)
 
 GEM
   remote: http://rubygems.org/

--- a/gemfiles/rails3.1.12.gemfile.lock
+++ b/gemfiles/rails3.1.12.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
-  remote: /Users/tom/src/personal/comma
+  remote: ..
   specs:
-    comma (3.0.4)
+    comma (3.0.5)
 
 GEM
   remote: http://rubygems.org/

--- a/gemfiles/rails3.2.11.gemfile.lock
+++ b/gemfiles/rails3.2.11.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
-  remote: /Users/tom/src/personal/comma
+  remote: ..
   specs:
-    comma (3.0.4)
+    comma (3.0.5)
 
 GEM
   remote: http://rubygems.org/

--- a/gemfiles/rails3.2.8.gemfile.lock
+++ b/gemfiles/rails3.2.8.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
-  remote: /Users/tom/development/projects/current/comma
+  remote: ..
   specs:
-    comma (3.0.3)
+    comma (3.0.5)
 
 GEM
   remote: http://rubygems.org/


### PR DESCRIPTION
Each time I do `rake appraisal`, it rewrites lockfiles. To prevent that, I rewrote to use relative path and current comma gem version.
