### PR TITLE
Add ActiveSupport to dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,15 +2,20 @@ PATH
   remote: .
   specs:
     comma (3.0.5)
+      activesupport (>= 3.0.0)
 
 GEM
   remote: http://rubygems.org/
   specs:
+    activesupport (3.2.14)
+      i18n (~> 0.6, >= 0.6.4)
+      multi_json (~> 1.0)
     appraisal (0.4.1)
       bundler
       rake
     diff-lcs (1.1.3)
     fastercsv (1.5.4)
+    i18n (0.6.5)
     multi_json (1.1.0)
     rake (0.9.2.2)
     rspec (2.8.0)

--- a/comma.gemspec
+++ b/comma.gemspec
@@ -15,16 +15,16 @@ Gem::Specification.new do |s|
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
-  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
   s.licenses = ['MIT']
 
-  s.add_development_dependency(%q<rake>, ["~> 0.9.2"])
-  s.add_development_dependency('sqlite3', '~> 1.3.4')
-  s.add_development_dependency(%q<appraisal>, ["~> 0.4.1"])
+  s.add_dependency 'activesupport', ['>= 3.0.0']
 
-  s.add_development_dependency('rspec', '~> 2.8.0')
-  s.add_development_dependency 'simplecov'
+  s.add_development_dependency 'rake', ['~> 0.9.2']
+  s.add_development_dependency 'sqlite3', ['~> 1.3.4']
+  s.add_development_dependency 'appraisal', ['~> 0.4.1']
+  s.add_development_dependency 'rspec', ['~> 2.8.0']
+  s.add_development_dependency 'simplecov', ['>= 0']
 
 end

--- a/gemfiles/active3.0.9.gemfile.lock
+++ b/gemfiles/active3.0.9.gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: ..
   specs:
     comma (3.0.5)
+      activesupport (>= 3.0.0)
 
 GEM
   remote: http://rubygems.org/

--- a/gemfiles/active3.1.1.gemfile.lock
+++ b/gemfiles/active3.1.1.gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: ..
   specs:
     comma (3.0.5)
+      activesupport (>= 3.0.0)
 
 GEM
   remote: http://rubygems.org/

--- a/gemfiles/active3.1.12.gemfile.lock
+++ b/gemfiles/active3.1.12.gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: ..
   specs:
     comma (3.0.5)
+      activesupport (>= 3.0.0)
 
 GEM
   remote: http://rubygems.org/

--- a/gemfiles/active3.2.11.gemfile.lock
+++ b/gemfiles/active3.2.11.gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: ..
   specs:
     comma (3.0.5)
+      activesupport (>= 3.0.0)
 
 GEM
   remote: http://rubygems.org/

--- a/gemfiles/active4.0.0.gemfile.lock
+++ b/gemfiles/active4.0.0.gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: ..
   specs:
     comma (3.0.5)
+      activesupport (>= 3.0.0)
 
 GEM
   remote: http://rubygems.org/

--- a/gemfiles/rails3.0.9.gemfile.lock
+++ b/gemfiles/rails3.0.9.gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: ..
   specs:
     comma (3.0.5)
+      activesupport (>= 3.0.0)
 
 GEM
   remote: http://rubygems.org/

--- a/gemfiles/rails3.1.1.gemfile.lock
+++ b/gemfiles/rails3.1.1.gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: ..
   specs:
     comma (3.0.5)
+      activesupport (>= 3.0.0)
 
 GEM
   remote: http://rubygems.org/

--- a/gemfiles/rails3.1.12.gemfile.lock
+++ b/gemfiles/rails3.1.12.gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: ..
   specs:
     comma (3.0.5)
+      activesupport (>= 3.0.0)
 
 GEM
   remote: http://rubygems.org/

--- a/gemfiles/rails3.2.11.gemfile.lock
+++ b/gemfiles/rails3.2.11.gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: ..
   specs:
     comma (3.0.5)
+      activesupport (>= 3.0.0)
 
 GEM
   remote: http://rubygems.org/

--- a/gemfiles/rails4.0.0.gemfile.lock
+++ b/gemfiles/rails4.0.0.gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: ..
   specs:
     comma (3.0.5)
+      activesupport (>= 3.0.0)
 
 GEM
   remote: http://rubygems.org/


### PR DESCRIPTION
Since `lib/comma.rb` requires some files in ActiveSupport and `Object`
is extented by using `class_attribute`, ActiveSupport should be added to
dependency.
