### PR TITLE
Add __use__ keyword to include other format definition

### DIFF
--- a/lib/comma/extractors.rb
+++ b/lib/comma/extractors.rb
@@ -2,19 +2,25 @@ module Comma
 
   class Extractor
 
-    def initialize(instance, &block)
+    def initialize(instance, style, formats)
       @instance = instance
-      @block = block
+      @style = style
+      @formats = formats
       @results = []
     end
 
     def results
-      instance_eval &@block
+      instance_eval &@formats[@style]
       @results.map { |r| convert_to_data_value(r) }
     end
 
     def id(*args, &block)
       method_missing(:id, *args, &block)
+    end
+
+    def __use__(style)
+      # TODO: prevent infinite recursion
+      instance_eval(&@formats[style])
     end
 
     private

--- a/lib/comma/object.rb
+++ b/lib/comma/object.rb
@@ -7,11 +7,11 @@ class Object
 
   def to_comma(style = :default)
     raise "No comma format for class #{self.class} defined for style #{style}" unless self.comma_formats and self.comma_formats[style]
-    Comma::DataExtractor.new(self, &self.comma_formats[style]).results
+    Comma::DataExtractor.new(self, style, self.class.comma_formats).results
   end
 
   def to_comma_headers(style = :default)
     raise "No comma format for class #{self.class} defined for style #{style}" unless self.comma_formats and self.comma_formats[style]
-    Comma::HeaderExtractor.new(self, &self.comma_formats[style]).results
+    Comma::HeaderExtractor.new(self, style, self.class.comma_formats).results
   end
 end

--- a/spec/comma/comma_spec.rb
+++ b/spec/comma/comma_spec.rb
@@ -225,3 +225,27 @@ describe Comma, 'to_comma data/headers object extensions' do
   end
 
 end
+
+describe Comma, '__use__ keyword' do
+  before(:all) do
+    @obj = Class.new(Struct.new(:id, :title, :description)) do
+      comma do
+        title
+        __use__ :description
+      end
+
+      comma :description do
+        __use__ :static
+        description
+      end
+
+      comma :static do
+        __static_column__ do 'Foo, Inc.' end
+      end
+    end.new(1, 'Programming Ruby', 'The Pickaxe book')
+  end
+
+  subject { @obj.to_comma }
+  its(:size) { should eq(3) }
+  it { should eq(['Programming Ruby', 'Foo, Inc.', 'The Pickaxe book']) }
+end


### PR DESCRIPTION
This is for issue #53. The issuer uses `extend` in example, but it is Ruby's keyword, so I used '**use**' instead.
