### PR TITLE
Yield model instance in __static_column__ keyword's block

### DIFF
--- a/lib/comma/extractors.rb
+++ b/lib/comma/extractors.rb
@@ -80,7 +80,7 @@ module Comma
     end
 
     def __static_column__(header = nil, &block)
-      @results << (block ? yield : nil)
+      @results << (block ? yield(@instance) : nil)
     end
 
     private

--- a/spec/comma/extractors_spec.rb
+++ b/spec/comma/extractors_spec.rb
@@ -127,12 +127,13 @@ describe Comma::DataExtractor, 'with static column method' do
         __static_column__
         __static_column__ 'STATIC'
         __static_column__ 'STATIC' do '' end
+        __static_column__ 'STATIC' do |o| o.name end
       end
     end.new(1, 'John Doe').to_comma
   end
 
   it 'should extract headers' do
-    @data.should eq([nil, nil, ''])
+    @data.should eq([nil, nil, '', 'John Doe'])
   end
 end
 


### PR DESCRIPTION
This gives `__static_column__` keyword more flexibility. For example, example in #41 can be written like:

``` ruby
comma do
  name
  description

  publisher :name

  publisher.custom_data.each do |header|
    __custom_column__ header do |o| o.custom_values[header] end
  end
end
```

I think that this is cleaner.
