### PR TITLE
Use :each for iterating when the scope has a limit or order clause

### DIFF
--- a/lib/comma/relation.rb
+++ b/lib/comma/relation.rb
@@ -1,5 +1,12 @@
 class ActiveRecord::Relation
   def to_comma(style = :default)
-    Comma::Generator.new(self, style).run(:find_each)
+    iterator_method =
+      if arel.ast.limit || !arel.ast.orders.empty?
+        Rails.logger.warn "#to_comma is being used on a relation with limit or order clauses. Falling back to iterating with :each. This can cause performance issues." if defined?(Rails)
+        :each
+      else
+        :find_each
+      end
+    Comma::Generator.new(self, style).run(iterator_method)
   end
 end

--- a/spec/comma/rails/active_record_spec.rb
+++ b/spec/comma/rails/active_record_spec.rb
@@ -78,13 +78,27 @@ if defined? ActiveRecord
       Picture.create(:name => 'photo.jpg', :imageable_id => @person.id, :imageable_type => 'Person')
     end
 
-    describe "case" do
+    describe "#to_comma on scopes" do
       it 'should extend ActiveRecord::NamedScope::Scope to add a #to_comma method which will return CSV content for objects within the scope' do
         Person.teenagers.to_comma.should == "Name,Age\nJunior,18\n"
       end
 
       it 'should find in batches' do
-        Person.teenagers.to_comma
+        scope = Person.teenagers
+        scope.should_receive(:find_each).and_yield @person
+        scope.to_comma
+      end
+
+      it 'should fall back to iterating with each when scope has limit clause' do
+        scope = Person.limit(1)
+        scope.should_receive(:each).and_yield @person
+        scope.to_comma
+      end
+
+      it 'should fall back to iterating with each when scope has order clause' do
+        scope = Person.order(:age)
+        scope.should_receive(:each).and_yield @person
+        scope.to_comma
       end
     end
 


### PR DESCRIPTION
By default comma uses `ActiveRecord::Batches#find_each` for iterating over an `ActiveRecord::Relation` scope. This can cause unexpected behaviour when the scope it's being run on has a limit or order clause. Neither of those work with `#find_each`.

For example, `Book.limit(5).to_comma` would ignore the limit and export all books as CSV. Likewise, `Book.order(:pub_date).to_comma` would ignore the order clause in the scope and export the books in the order of their private keys.

My proposed solution checks whether there are limit or order clauses in the scope and in those cases uses the `:each` iterator instead of `:find_each`. It also emits a warning to the logs explaining that falling back to using `:each` might cause performance issues.
