### PR TITLE
Remove deprecation warning

### DIFF
--- a/lib/comma.rb
+++ b/lib/comma.rb
@@ -45,7 +45,7 @@ ActiveSupport.on_load(:action_controller) do
     ActionController::Renderers.add :csv do |obj, options|
       filename    = options[:filename]  || 'data'
       extension   = options[:extension] || 'csv'
-      mime_type   = options[:mime_type] || Mime::CSV
+      mime_type   = options[:mime_type] || Mime[:csv]
       #Capture any CSV optional settings passed to comma or comma specific options
       csv_options = options.slice(*CSV_HANDLER::DEFAULT_OPTIONS.merge(Comma::DEFAULT_OPTIONS).keys)
       send_data obj.to_comma(csv_options), :type => mime_type, :disposition => "attachment; filename=\"#{filename}.#{extension}\""


### PR DESCRIPTION
Removed the following warning thrown when using rails 5:

`DEPRECATION WARNING: Accessing mime types via constants is deprecated. Please change 'Mime::CSV' to 'Mime[:csv]'.`