### PR TITLE
Add option to add UTF-8 BOM

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,7 +46,7 @@ GEM
       multi_json (~> 1.0)
       simplecov-html (~> 0.9.0)
     simplecov-html (0.9.0)
-    sqlite3 (1.3.5)
+    sqlite3 (1.3.11)
     thor (0.19.1)
 
 PLATFORMS
@@ -61,3 +61,6 @@ DEPENDENCIES
   rest-client (> 1.6.2, < 1.7)
   rspec (~> 2.8.0)
   sqlite3 (~> 1.3.4)
+
+BUNDLED WITH
+   1.12.5

--- a/lib/comma.rb
+++ b/lib/comma.rb
@@ -46,9 +46,12 @@ ActiveSupport.on_load(:action_controller) do
       filename    = options[:filename]  || 'data'
       extension   = options[:extension] || 'csv'
       mime_type   = options[:mime_type] || Mime::CSV
+      add_bom     = options[:add_bom]   || false
       #Capture any CSV optional settings passed to comma or comma specific options
       csv_options = options.slice(*CSV_HANDLER::DEFAULT_OPTIONS.merge(Comma::DEFAULT_OPTIONS).keys)
-      send_data obj.to_comma(csv_options), :type => mime_type, :disposition => "attachment; filename=\"#{filename}.#{extension}\""
+      data = obj.to_comma(csv_options)
+      data = "\xEF\xBB\xBF#{data}" if add_bom
+      send_data data, :type => mime_type, :disposition => "attachment; filename=\"#{filename}.#{extension}\""
     end
   end
 end

--- a/lib/comma.rb
+++ b/lib/comma.rb
@@ -46,11 +46,11 @@ ActiveSupport.on_load(:action_controller) do
       filename    = options[:filename]  || 'data'
       extension   = options[:extension] || 'csv'
       mime_type   = options[:mime_type] || Mime::CSV
-      add_bom     = options[:add_bom]   || false
+      with_bom    = options[:with_bom]  || false
       #Capture any CSV optional settings passed to comma or comma specific options
       csv_options = options.slice(*CSV_HANDLER::DEFAULT_OPTIONS.merge(Comma::DEFAULT_OPTIONS).keys)
       data = obj.to_comma(csv_options)
-      data = "\xEF\xBB\xBF#{data}" if add_bom
+      data = "\xEF\xBB\xBF#{data}" if with_bom
       send_data data, :type => mime_type, :disposition => "attachment; filename=\"#{filename}.#{extension}\""
     end
   end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -103,6 +103,18 @@ if defined?(Rails)
           response.content_type.should      == 'text/plain'
         end
 
+        it 'should allow bom to be set' do
+          get :with_custom_options, :format => :csv, :custom_options => { :with_bom => true }
+
+          expected_content =<<-CSV.gsub(/^\s+/,'')
+          \xEF\xBB\xBFFirst name,Last name
+          Fred,Flintstone
+          Wilma,Flintstone
+          CSV
+
+          response.body.should              == expected_content
+        end
+
         describe 'headers' do
 
           it 'should allow toggling on' do


### PR DESCRIPTION
This PR adds the `with_bom` option.
- I added a spec as well, near where you test the other options, but was unable to see it run due to the need for a dummy app and all. perhaps someone who already has a testing environment set up can make sure it works.
- I had to update the `sqlite3` gem version. The old one just refused to be built, probably due to my ruby version.
