### PR TITLE
Homepage link is pointing to a defunct fork

### DIFF
--- a/comma.gemspec
+++ b/comma.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.version     = Comma::VERSION
   s.authors     = ["Marcus Crafter", "Tom Meier"]
   s.email       = ["crafterm@redartisan.com", "tom@venombytes.com"]
-  s.homepage    = "http://github.com/crafterm/comma"
+  s.homepage    = "http://github.com/comma-csv/comma"
   s.summary     = %q{Ruby Comma Seperated Values generation library}
   s.description = %q{Ruby Comma Seperated Values generation library}
 


### PR DESCRIPTION
The link associated with the `.gemspec` homepage is a fork that is no longer maintained, and whose latest version does not coincide with the current version for this repo.