### PR TITLE
Add UTF-8 BOM at the beginning of the data

### DIFF
--- a/lib/comma.rb
+++ b/lib/comma.rb
@@ -51,7 +51,7 @@ ActiveSupport.on_load(:action_controller) do
       end
       data = obj.to_comma(csv_options)
       disposition = "attachment; filename=\"#{filename}.#{extension}\""
-      send_data data, type: mime_type, disposition: disposition
+      send_data "\uFEFF" + data, type: mime_type, disposition: disposition
     end
   end
 end


### PR DESCRIPTION
To make Excel open UTF-8 encoded CSV files correctly a BOM mark is needed. 
