### PR TITLE
Update README with latest gem version

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Comma is distributed as a gem, best installed via Bundler.
 Include the gem in your Gemfile:
 
 ```ruby
-gem 'comma', '~> 4.5.0'
+gem 'comma', '~> 4.7.0'
 ```
 
 Or, if you want to live life on the edge, you can get master from the main comma repository:


### PR DESCRIPTION
Version `4.5.0`, which is referenced in the README, doesn't work with new versions of `ActiveSupport`: 

```
Bundler could not find compatible versions for gem "activesupport":
  In snapshot (Gemfile.lock):
    activesupport (= 7.0.2.4)

  In Gemfile:
    comma (~> 4.5.0) was resolved to 4.5.0, which depends on
      activesupport (< 6.2, >= 4.2.0)

    rails (~> 7.0.2.3) was resolved to 7.0.2.4, which depends on
      activesupport (= 7.0.2.4)

Running `bundle update` will rebuild your snapshot from scratch, using only
the gems in your Gemfile, which may resolve the conflict.
```