### PR TITLE
Add CSV gem dependency ready for Ruby 3.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     comma (4.8.0)
       activesupport (>= 4.2.0)
+      csv (>= 3.3)
 
 GEM
   remote: https://rubygems.org/
@@ -34,6 +35,7 @@ GEM
       term-ansicolor (~> 1.3)
       thor (>= 0.19.4, < 2.0)
       tins (~> 1.6)
+    csv (3.3.0)
     diff-lcs (1.2.5)
     docile (1.4.0)
     drb (2.2.0)

--- a/comma.gemspec
+++ b/comma.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.licenses = ['MIT']
 
   s.add_dependency 'activesupport', '>= 4.2.0'
+  s.add_dependency 'csv', '>= 3.3'
 
   s.add_development_dependency 'appraisal', ['~> 1.0.0']
   s.add_development_dependency 'minitest', '5.14.4'


### PR DESCRIPTION
Fixes the deprecation warning:

> warning: csv was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add csv to your Gemfile or gemspec