### PR TITLE
fix: support Ruby 3.4 and expand CI coverage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,12 +3,14 @@ on: [push, pull_request]
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
-        ruby: ['3.0', '3.1', '3.2', '3.3']
+        ruby: ['3.0', '3.1', '3.2', '3.3', '3.4']
         gemfile: ['active6.0.6', 'active6.1.7.6', 'active7.0.8', 'active7.1.3', 'rails6.0.6', 'rails6.1.7.6', 'rails7.0.8', 'rails7.1.3']
     runs-on: ubuntu-latest
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/${{ matrix.gemfile }}.gemfile
+      BUNDLE_FORCE_RUBY_PLATFORM: ${{ matrix.ruby == '3.4' }}
       RUBY_OPT: --disable=did_you_mean
     services:
       mongodb:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     comma (4.8.0)
       activesupport (>= 4.2.0)
+      csv (>= 3.3)
 
 GEM
   remote: https://rubygems.org/
@@ -34,6 +35,7 @@ GEM
       term-ansicolor (~> 1.3)
       thor (>= 0.19.4, < 2.0)
       tins (~> 1.6)
+    csv (3.3.0)
     diff-lcs (1.2.5)
     docile (1.4.0)
     drb (2.2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,27 +25,26 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
-    bigdecimal (3.1.6)
-    concurrent-ruby (1.2.3)
-    connection_pool (2.4.1)
+    base64 (0.3.0)
+    bigdecimal (4.1.2)
+    concurrent-ruby (1.3.6)
+    connection_pool (2.5.5)
     coveralls (0.8.23)
       json (>= 1.8, < 3)
       simplecov (~> 0.16.1)
       term-ansicolor (~> 1.3)
       thor (>= 0.19.4, < 2.0)
       tins (~> 1.6)
-    csv (3.3.0)
+    csv (3.3.5)
     diff-lcs (1.2.5)
     docile (1.4.0)
-    drb (2.2.0)
-      ruby2_keywords
-    i18n (1.14.1)
+    drb (2.2.3)
+    i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     json (2.7.1)
     mini_portile2 (2.8.5)
     minitest (5.14.4)
-    mutex_m (0.2.0)
+    mutex_m (0.3.0)
     parallel (1.24.0)
     parser (3.3.0.4)
       ast (~> 2.4.1)
@@ -90,7 +89,6 @@ GEM
       rubocop (>= 0.90.0, < 2.0)
       rubocop-ast (>= 0.4.0)
     ruby-progressbar (1.13.0)
-    ruby2_keywords (0.0.5)
     simplecov (0.16.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)
@@ -113,9 +111,13 @@ PLATFORMS
 
 DEPENDENCIES
   appraisal (~> 1.0.0)
+  base64
+  bigdecimal
   comma!
   coveralls
+  drb
   minitest (= 5.14.4)
+  mutex_m
   rake (~> 13.0.1)
   rspec (~> 3.5.0)
   rspec-activemodel-mocks

--- a/comma.gemspec
+++ b/comma.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.licenses = ['MIT']
 
   s.add_dependency 'activesupport', '>= 4.2.0'
+  s.add_dependency 'csv', '>= 3.3'
 
   s.add_development_dependency 'appraisal', ['~> 1.0.0']
   s.add_development_dependency 'minitest', '5.14.4'

--- a/comma.gemspec
+++ b/comma.gemspec
@@ -22,7 +22,11 @@ Gem::Specification.new do |s|
   s.add_dependency 'csv', '>= 3.3'
 
   s.add_development_dependency 'appraisal', ['~> 1.0.0']
+  s.add_development_dependency 'base64'
+  s.add_development_dependency 'bigdecimal'
+  s.add_development_dependency 'drb'
   s.add_development_dependency 'minitest', '5.14.4'
+  s.add_development_dependency 'mutex_m'
   s.add_development_dependency 'rake', '~> 13.0.1'
   s.add_development_dependency 'rspec', ['~> 3.5.0']
   s.add_development_dependency 'rspec-activemodel-mocks'

--- a/gemfiles/active6.0.6.gemfile.lock
+++ b/gemfiles/active6.0.6.gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     comma (4.8.0)
       activesupport (>= 4.2.0)
+      csv (>= 3.3)
 
 GEM
   remote: https://rubygems.org/
@@ -23,20 +24,25 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    concurrent-ruby (1.2.3)
+    base64 (0.3.0)
+    bigdecimal (4.1.2)
+    concurrent-ruby (1.3.6)
     coveralls (0.8.23)
       json (>= 1.8, < 3)
       simplecov (~> 0.16.1)
       term-ansicolor (~> 1.3)
       thor (>= 0.19.4, < 2.0)
       tins (~> 1.6)
+    csv (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
-    i18n (1.14.1)
+    drb (2.2.3)
+    i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     json (2.7.1)
-    mini_portile2 (2.8.5)
+    mini_portile2 (2.8.9)
     minitest (5.14.4)
+    mutex_m (0.3.0)
     parallel (1.24.0)
     parser (3.3.0.4)
       ast (~> 2.4.1)
@@ -88,6 +94,8 @@ GEM
     simplecov-html (0.10.2)
     sqlite3 (1.7.0)
       mini_portile2 (~> 2.8.0)
+    sqlite3 (1.7.0-x86_64-darwin)
+    sqlite3 (1.7.0-x86_64-linux)
     sync (0.5.0)
     term-ansicolor (1.7.1)
       tins (~> 1.0)
@@ -98,18 +106,24 @@ GEM
     tzinfo (1.2.11)
       thread_safe (~> 0.1)
     unicode-display_width (2.5.0)
-    zeitwerk (2.6.12)
+    zeitwerk (2.6.18)
 
 PLATFORMS
   ruby
+  x86_64-darwin-23
+  x86_64-linux
 
 DEPENDENCIES
   activerecord (= 6.0.6)
   activesupport (= 6.0.6)
   appraisal (~> 1.0.0)
+  base64
+  bigdecimal
   comma!
   coveralls
+  drb
   minitest (= 5.14.4)
+  mutex_m
   rake (~> 13.0.1)
   rspec (~> 3.5.0)
   rspec-activemodel-mocks

--- a/gemfiles/active6.1.7.6.gemfile.lock
+++ b/gemfiles/active6.1.7.6.gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     comma (4.8.0)
       activesupport (>= 4.2.0)
+      csv (>= 3.3)
 
 GEM
   remote: https://rubygems.org/
@@ -23,20 +24,25 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    concurrent-ruby (1.2.3)
+    base64 (0.3.0)
+    bigdecimal (4.1.2)
+    concurrent-ruby (1.3.6)
     coveralls (0.8.23)
       json (>= 1.8, < 3)
       simplecov (~> 0.16.1)
       term-ansicolor (~> 1.3)
       thor (>= 0.19.4, < 2.0)
       tins (~> 1.6)
+    csv (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
-    i18n (1.14.1)
+    drb (2.2.3)
+    i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     json (2.7.1)
-    mini_portile2 (2.8.5)
+    mini_portile2 (2.8.9)
     minitest (5.14.4)
+    mutex_m (0.3.0)
     parallel (1.24.0)
     parser (3.3.0.4)
       ast (~> 2.4.1)
@@ -88,6 +94,8 @@ GEM
     simplecov-html (0.10.2)
     sqlite3 (1.7.0)
       mini_portile2 (~> 2.8.0)
+    sqlite3 (1.7.0-x86_64-darwin)
+    sqlite3 (1.7.0-x86_64-linux)
     sync (0.5.0)
     term-ansicolor (1.7.1)
       tins (~> 1.0)
@@ -97,18 +105,24 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
-    zeitwerk (2.6.12)
+    zeitwerk (2.6.18)
 
 PLATFORMS
   ruby
+  x86_64-darwin-23
+  x86_64-linux
 
 DEPENDENCIES
   activerecord (= 6.1.7.6)
   activesupport (= 6.1.7.6)
   appraisal (~> 1.0.0)
+  base64
+  bigdecimal
   comma!
   coveralls
+  drb
   minitest (= 5.14.4)
+  mutex_m
   rake (~> 13.0.1)
   rspec (~> 3.5.0)
   rspec-activemodel-mocks

--- a/gemfiles/active7.0.8.gemfile.lock
+++ b/gemfiles/active7.0.8.gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     comma (4.8.0)
       activesupport (>= 4.2.0)
+      csv (>= 3.3)
 
 GEM
   remote: https://rubygems.org/
@@ -22,20 +23,25 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    concurrent-ruby (1.2.3)
+    base64 (0.3.0)
+    bigdecimal (4.1.2)
+    concurrent-ruby (1.3.6)
     coveralls (0.8.23)
       json (>= 1.8, < 3)
       simplecov (~> 0.16.1)
       term-ansicolor (~> 1.3)
       thor (>= 0.19.4, < 2.0)
       tins (~> 1.6)
+    csv (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
-    i18n (1.14.1)
+    drb (2.2.3)
+    i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     json (2.7.1)
-    mini_portile2 (2.8.5)
+    mini_portile2 (2.8.9)
     minitest (5.14.4)
+    mutex_m (0.3.0)
     parallel (1.24.0)
     parser (3.3.0.4)
       ast (~> 2.4.1)
@@ -87,6 +93,8 @@ GEM
     simplecov-html (0.10.2)
     sqlite3 (1.7.0)
       mini_portile2 (~> 2.8.0)
+    sqlite3 (1.7.0-x86_64-darwin)
+    sqlite3 (1.7.0-x86_64-linux)
     sync (0.5.0)
     term-ansicolor (1.7.1)
       tins (~> 1.0)
@@ -99,14 +107,20 @@ GEM
 
 PLATFORMS
   ruby
+  x86_64-darwin-23
+  x86_64-linux
 
 DEPENDENCIES
   activerecord (= 7.0.8)
   activesupport (= 7.0.8)
   appraisal (~> 1.0.0)
+  base64
+  bigdecimal
   comma!
   coveralls
+  drb
   minitest (= 5.14.4)
+  mutex_m
   rake (~> 13.0.1)
   rspec (~> 3.5.0)
   rspec-activemodel-mocks

--- a/gemfiles/active7.1.3.gemfile.lock
+++ b/gemfiles/active7.1.3.gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     comma (4.8.0)
       activesupport (>= 4.2.0)
+      csv (>= 3.3)
 
 GEM
   remote: https://rubygems.org/
@@ -28,26 +29,26 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
-    bigdecimal (3.1.6)
-    concurrent-ruby (1.2.3)
-    connection_pool (2.4.1)
+    base64 (0.3.0)
+    bigdecimal (4.1.2)
+    concurrent-ruby (1.3.6)
+    connection_pool (2.5.5)
     coveralls (0.8.23)
       json (>= 1.8, < 3)
       simplecov (~> 0.16.1)
       term-ansicolor (~> 1.3)
       thor (>= 0.19.4, < 2.0)
       tins (~> 1.6)
+    csv (3.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
-    drb (2.2.0)
-      ruby2_keywords
-    i18n (1.14.1)
+    drb (2.2.3)
+    i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     json (2.7.1)
     mini_portile2 (2.8.5)
     minitest (5.14.4)
-    mutex_m (0.2.0)
+    mutex_m (0.3.0)
     parallel (1.24.0)
     parser (3.3.0.4)
       ast (~> 2.4.1)
@@ -92,7 +93,6 @@ GEM
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
     ruby-progressbar (1.13.0)
-    ruby2_keywords (0.0.5)
     simplecov (0.16.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)
@@ -100,6 +100,7 @@ GEM
     simplecov-html (0.10.2)
     sqlite3 (1.7.0)
       mini_portile2 (~> 2.8.0)
+    sqlite3 (1.7.0-x86_64-linux)
     sync (0.5.0)
     term-ansicolor (1.7.1)
       tins (~> 1.0)
@@ -113,14 +114,19 @@ GEM
 
 PLATFORMS
   ruby
+  x86_64-linux
 
 DEPENDENCIES
   activerecord (= 7.1.3)
   activesupport (= 7.1.3)
   appraisal (~> 1.0.0)
+  base64
+  bigdecimal
   comma!
   coveralls
+  drb
   minitest (= 5.14.4)
+  mutex_m
   rake (~> 13.0.1)
   rspec (~> 3.5.0)
   rspec-activemodel-mocks

--- a/gemfiles/rails6.0.6.gemfile.lock
+++ b/gemfiles/rails6.0.6.gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     comma (4.8.0)
       activesupport (>= 4.2.0)
+      csv (>= 3.3)
 
 GEM
   remote: https://rubygems.org/
@@ -67,8 +68,10 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
+    base64 (0.3.0)
+    bigdecimal (4.1.2)
     builder (3.2.4)
-    concurrent-ruby (1.2.3)
+    concurrent-ruby (1.3.6)
     coveralls (0.8.23)
       json (>= 1.8, < 3)
       simplecov (~> 0.16.1)
@@ -76,13 +79,15 @@ GEM
       thor (>= 0.19.4, < 2.0)
       tins (~> 1.6)
     crass (1.0.6)
+    csv (3.3.5)
     date (3.3.4)
     diff-lcs (1.5.0)
     docile (1.4.0)
+    drb (2.2.3)
     erubi (1.12.0)
     globalid (1.1.0)
       activesupport (>= 5.0)
-    i18n (1.14.1)
+    i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     json (2.7.1)
     loofah (2.22.0)
@@ -96,8 +101,9 @@ GEM
     marcel (1.0.2)
     method_source (1.0.0)
     mini_mime (1.1.5)
-    mini_portile2 (2.8.5)
+    mini_portile2 (2.8.9)
     minitest (5.14.4)
+    mutex_m (0.3.0)
     net-imap (0.4.9.1)
       date
       net-protocol
@@ -111,13 +117,7 @@ GEM
     nokogiri (1.16.0)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
-    nokogiri (1.16.0-aarch64-linux)
-      racc (~> 1.4)
-    nokogiri (1.16.0-arm-linux)
-      racc (~> 1.4)
-    nokogiri (1.16.0-arm64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.16.0-x86-linux)
+    nokogiri (1.16.0-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.16.0-x86_64-linux)
       racc (~> 1.4)
@@ -219,10 +219,7 @@ GEM
       sprockets (>= 3.0.0)
     sqlite3 (1.7.0)
       mini_portile2 (~> 2.8.0)
-    sqlite3 (1.7.0-aarch64-linux)
-    sqlite3 (1.7.0-arm-linux)
-    sqlite3 (1.7.0-arm64-darwin)
-    sqlite3 (1.7.0-x86-linux)
+    sqlite3 (1.7.0-x86_64-darwin)
     sqlite3 (1.7.0-x86_64-linux)
     sync (0.5.0)
     term-ansicolor (1.7.1)
@@ -240,21 +237,22 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    zeitwerk (2.6.12)
+    zeitwerk (2.6.18)
 
 PLATFORMS
-  aarch64-linux
-  arm-linux
-  arm64-darwin
   ruby
-  x86-linux
+  x86_64-darwin-23
   x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 1.0.0)
+  base64
+  bigdecimal
   comma!
   coveralls
+  drb
   minitest (= 5.14.4)
+  mutex_m
   rails (= 6.0.6)
   rake (~> 13.0.1)
   rspec (~> 3.5.0)

--- a/gemfiles/rails6.1.7.6.gemfile.lock
+++ b/gemfiles/rails6.1.7.6.gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     comma (4.8.0)
       activesupport (>= 4.2.0)
+      csv (>= 3.3)
 
 GEM
   remote: https://rubygems.org/
@@ -71,8 +72,10 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
+    base64 (0.3.0)
+    bigdecimal (4.1.2)
     builder (3.2.4)
-    concurrent-ruby (1.2.3)
+    concurrent-ruby (1.3.6)
     coveralls (0.8.23)
       json (>= 1.8, < 3)
       simplecov (~> 0.16.1)
@@ -80,13 +83,15 @@ GEM
       thor (>= 0.19.4, < 2.0)
       tins (~> 1.6)
     crass (1.0.6)
+    csv (3.3.5)
     date (3.3.4)
     diff-lcs (1.5.0)
     docile (1.4.0)
+    drb (2.2.3)
     erubi (1.12.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
-    i18n (1.14.1)
+    i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     json (2.7.1)
     loofah (2.22.0)
@@ -100,8 +105,9 @@ GEM
     marcel (1.0.2)
     method_source (1.0.0)
     mini_mime (1.1.5)
-    mini_portile2 (2.8.5)
+    mini_portile2 (2.8.9)
     minitest (5.14.4)
+    mutex_m (0.3.0)
     net-imap (0.4.9.1)
       date
       net-protocol
@@ -115,13 +121,7 @@ GEM
     nokogiri (1.16.0)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
-    nokogiri (1.16.0-aarch64-linux)
-      racc (~> 1.4)
-    nokogiri (1.16.0-arm-linux)
-      racc (~> 1.4)
-    nokogiri (1.16.0-arm64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.16.0-x86-linux)
+    nokogiri (1.16.0-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.16.0-x86_64-linux)
       racc (~> 1.4)
@@ -223,10 +223,7 @@ GEM
       sprockets (>= 3.0.0)
     sqlite3 (1.7.0)
       mini_portile2 (~> 2.8.0)
-    sqlite3 (1.7.0-aarch64-linux)
-    sqlite3 (1.7.0-arm-linux)
-    sqlite3 (1.7.0-arm64-darwin)
-    sqlite3 (1.7.0-x86-linux)
+    sqlite3 (1.7.0-x86_64-darwin)
     sqlite3 (1.7.0-x86_64-linux)
     sync (0.5.0)
     term-ansicolor (1.7.1)
@@ -243,21 +240,22 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    zeitwerk (2.6.12)
+    zeitwerk (2.6.18)
 
 PLATFORMS
-  aarch64-linux
-  arm-linux
-  arm64-darwin
   ruby
-  x86-linux
+  x86_64-darwin-23
   x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 1.0.0)
+  base64
+  bigdecimal
   comma!
   coveralls
+  drb
   minitest (= 5.14.4)
+  mutex_m
   rails (= 6.1.7.6)
   rake (~> 13.0.1)
   rspec (~> 3.5.0)

--- a/gemfiles/rails7.0.8.gemfile.lock
+++ b/gemfiles/rails7.0.8.gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     comma (4.8.0)
       activesupport (>= 4.2.0)
+      csv (>= 3.3)
 
 GEM
   remote: https://rubygems.org/
@@ -77,8 +78,10 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
+    base64 (0.3.0)
+    bigdecimal (4.1.2)
     builder (3.2.4)
-    concurrent-ruby (1.2.3)
+    concurrent-ruby (1.3.6)
     coveralls (0.8.23)
       json (>= 1.8, < 3)
       simplecov (~> 0.16.1)
@@ -86,13 +89,15 @@ GEM
       thor (>= 0.19.4, < 2.0)
       tins (~> 1.6)
     crass (1.0.6)
+    csv (3.3.5)
     date (3.3.4)
     diff-lcs (1.5.0)
     docile (1.4.0)
+    drb (2.2.3)
     erubi (1.12.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
-    i18n (1.14.1)
+    i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     json (2.7.1)
     loofah (2.22.0)
@@ -106,8 +111,9 @@ GEM
     marcel (1.0.2)
     method_source (1.0.0)
     mini_mime (1.1.5)
-    mini_portile2 (2.8.5)
+    mini_portile2 (2.8.9)
     minitest (5.14.4)
+    mutex_m (0.3.0)
     net-imap (0.4.9.1)
       date
       net-protocol
@@ -120,6 +126,10 @@ GEM
     nio4r (2.7.0)
     nokogiri (1.16.0)
       mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
+    nokogiri (1.16.0-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.16.0-x86_64-linux)
       racc (~> 1.4)
     parallel (1.24.0)
     parser (3.3.0.4)
@@ -211,6 +221,8 @@ GEM
     simplecov-html (0.10.2)
     sqlite3 (1.7.0)
       mini_portile2 (~> 2.8.0)
+    sqlite3 (1.7.0-x86_64-darwin)
+    sqlite3 (1.7.0-x86_64-linux)
     sync (0.5.0)
     term-ansicolor (1.7.1)
       tins (~> 1.0)
@@ -228,12 +240,18 @@ GEM
 
 PLATFORMS
   ruby
+  x86_64-darwin-23
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 1.0.0)
+  base64
+  bigdecimal
   comma!
   coveralls
+  drb
   minitest (= 5.14.4)
+  mutex_m
   rails (= 7.0.8)
   rake (~> 13.0.1)
   rspec (~> 3.5.0)

--- a/gemfiles/rails7.1.3.gemfile.lock
+++ b/gemfiles/rails7.1.3.gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     comma (4.8.0)
       activesupport (>= 4.2.0)
+      csv (>= 3.3)
 
 GEM
   remote: https://rubygems.org/
@@ -86,11 +87,11 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
-    bigdecimal (3.1.6)
+    base64 (0.3.0)
+    bigdecimal (4.1.2)
     builder (3.2.4)
-    concurrent-ruby (1.2.3)
-    connection_pool (2.4.1)
+    concurrent-ruby (1.3.6)
+    connection_pool (2.5.5)
     coveralls (0.8.23)
       json (>= 1.8, < 3)
       simplecov (~> 0.16.1)
@@ -98,15 +99,15 @@ GEM
       thor (>= 0.19.4, < 2.0)
       tins (~> 1.6)
     crass (1.0.6)
+    csv (3.3.5)
     date (3.3.4)
     diff-lcs (1.5.0)
     docile (1.4.0)
-    drb (2.2.0)
-      ruby2_keywords
+    drb (2.2.3)
     erubi (1.12.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
-    i18n (1.14.1)
+    i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     io-console (0.7.2)
     irb (1.11.1)
@@ -125,7 +126,7 @@ GEM
     mini_mime (1.1.5)
     mini_portile2 (2.8.5)
     minitest (5.14.4)
-    mutex_m (0.2.0)
+    mutex_m (0.3.0)
     net-imap (0.4.9.1)
       date
       net-protocol
@@ -138,6 +139,8 @@ GEM
     nio4r (2.7.0)
     nokogiri (1.16.0)
       mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
+    nokogiri (1.16.0-x86_64-linux)
       racc (~> 1.4)
     parallel (1.24.0)
     parser (3.3.0.4)
@@ -234,7 +237,6 @@ GEM
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
     ruby-progressbar (1.13.0)
-    ruby2_keywords (0.0.5)
     simplecov (0.16.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)
@@ -242,6 +244,7 @@ GEM
     simplecov-html (0.10.2)
     sqlite3 (1.7.0)
       mini_portile2 (~> 2.8.0)
+    sqlite3 (1.7.0-x86_64-linux)
     stringio (3.1.0)
     sync (0.5.0)
     term-ansicolor (1.7.1)
@@ -261,12 +264,17 @@ GEM
 
 PLATFORMS
   ruby
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 1.0.0)
+  base64
+  bigdecimal
   comma!
   coveralls
+  drb
   minitest (= 5.14.4)
+  mutex_m
   rails (= 7.1.3)
   rake (~> 13.0.1)
   rspec (~> 3.5.0)

--- a/lib/comma.rb
+++ b/lib/comma.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'csv'
+require 'logger'
 CSV_HANDLER = CSV
 
 module Comma

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@
 require 'rubygems'
 $LOAD_PATH.unshift(File.expand_path(File.join('..', '..', 'lib'), __FILE__))
 
+require 'logger'
 require 'simplecov'
 require 'coveralls'
 SimpleCov.formatter = Coveralls::SimpleCov::Formatter


### PR DESCRIPTION
## Summary
- add csv as a runtime dependency so the gem loads on Ruby 3.4+
- extend GitHub Actions to run Ruby 3.4 across the existing matrix
- add targeted Ruby 4.0 coverage on the latest ActiveRecord and Rails appraisals

## Testing
- bundle install
- bundle exec rspec spec
- bundle exec rspec spec/comma/comma_spec.rb:205
- bundle exec rubocop -P
- bundle exec rake build