### PR TITLE
ci: add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4'
+          bundler-cache: true
+
+      - run: bundle exec rspec spec
+
+      - run: bundle exec rubocop -P
+
+      - run: bundle exec rake build
+
+      - name: Publish gem to RubyGems
+        env:
+          GEM_HOST_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
+        run: gem push pkg/*.gem
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: pkg/*.gem
+          generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -120,6 +120,19 @@ You can also run a specific spec under one appraisal:
 bundle exec appraisal rails7.1.3 bundle exec rspec spec/controllers/users_controller_spec.rb
 ```
 
+## Releasing
+
+Releases are created from git tags. After the version bump PR is merged into `master`, create and push a tag such as `v4.9.0`.
+
+```sh
+$ git checkout master
+$ git pull --ff-only origin master
+$ git tag v4.9.0
+$ git push origin v4.9.0
+```
+
+Pushing the tag triggers `.github/workflows/release.yml`, which runs the base test suite, builds the gem, publishes it to RubyGems, and creates the matching GitHub Release. The workflow expects the repository secret `RUBYGEMS_API_KEY` to be configured.
+
 ## Contributing
 
 Please make sure `bundle exec rspec spec`, `bundle exec rubocop -P`, and any relevant `bundle exec appraisal ...` commands pass before opening a pull request.


### PR DESCRIPTION
## Summary
- add a tag-driven GitHub Actions workflow for releases
- publish gems to RubyGems and create a GitHub Release from the built artifact
- document the tag-based release process in the README
